### PR TITLE
👽 Chore: Update kubernetes tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,11 @@ No modules.
 |------|-------------|
 | <a name="output_net_cidr_block"></a> [net\_cidr\_block](#output\_net\_cidr\_block) | The CIDR block of the Outscale Net. |
 | <a name="output_net_id"></a> [net\_id](#output\_net\_id) | The ID of the Outscale Net. |
+| <a name="output_private_route_tables"></a> [private\_route\_tables](#output\_private\_route\_tables) | List of private route table IDs. |
 | <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | List of private subnet IDs. |
 | <a name="output_public_ip_for_private_nat_service"></a> [public\_ip\_for\_private\_nat\_service](#output\_public\_ip\_for\_private\_nat\_service) | List of public IPs for NAT service in private subnets. |
 | <a name="output_public_ip_for_storage_nat_service"></a> [public\_ip\_for\_storage\_nat\_service](#output\_public\_ip\_for\_storage\_nat\_service) | List of public IPs for NAT service in storage subnets. |
+| <a name="output_public_route_tables"></a> [public\_route\_tables](#output\_public\_route\_tables) | List of public route table IDs. |
 | <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | List of public subnet IDs. |
 | <a name="output_storage_subnets"></a> [storage\_subnets](#output\_storage\_subnets) | List of storage subnet IDs. |
 <!-- END_TF_DOCS -->

--- a/locals.tf
+++ b/locals.tf
@@ -132,6 +132,17 @@ locals {
   # Kubernetes Cluster Tags
   ####################################################################################################################
   kubernetes_net_tags    = var.kubernetes_support ? [{ key = format("OscK8sClusterID/%s", var.kubernetes_cluster_name), value = "shared" }] : []
-  kubernetes_subnet_tags = var.kubernetes_support ? [{ key = format("OscK8sClusterID/%s", var.kubernetes_cluster_name), value = "shared" }] : []
+  kubernetes_public_subnet_tags  = var.kubernetes_support ? [
+    { key = format("OscK8sClusterID/%s", var.kubernetes_cluster_name), value = "shared" },
+    { key = "OscK8sRole/service" , value = "true" }
+  ] : []
+  kubernetes_private_subnet_tags = var.kubernetes_support ? [
+    { key = format("OscK8sClusterID/%s", var.kubernetes_cluster_name), value = "shared" },
+    { key = "OscK8sRole/service.internal" , value = "true" }
+  ] : []
+  kubernetes_storage_subnet_tags = var.kubernetes_support ? [
+    { key = format("OscK8sClusterID/%s", var.kubernetes_cluster_name), value = "shared" },
+    { key = "OscK8sRole/service.internal" , value = "true" }
+  ] : []
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -131,18 +131,18 @@ locals {
   ####################################################################################################################
   # Kubernetes Cluster Tags
   ####################################################################################################################
-  kubernetes_net_tags    = var.kubernetes_support ? [{ key = format("OscK8sClusterID/%s", var.kubernetes_cluster_name), value = "shared" }] : []
-  kubernetes_public_subnet_tags  = var.kubernetes_support ? [
+  kubernetes_net_tags = var.kubernetes_support ? [{ key = format("OscK8sClusterID/%s", var.kubernetes_cluster_name), value = "shared" }] : []
+  kubernetes_public_subnet_tags = var.kubernetes_support ? [
     { key = format("OscK8sClusterID/%s", var.kubernetes_cluster_name), value = "shared" },
-    { key = "OscK8sRole/service" , value = "true" }
+    { key = "OscK8sRole/service", value = "true" }
   ] : []
   kubernetes_private_subnet_tags = var.kubernetes_support ? [
     { key = format("OscK8sClusterID/%s", var.kubernetes_cluster_name), value = "shared" },
-    { key = "OscK8sRole/service.internal" , value = "true" }
+    { key = "OscK8sRole/service.internal", value = "true" }
   ] : []
   kubernetes_storage_subnet_tags = var.kubernetes_support ? [
     { key = format("OscK8sClusterID/%s", var.kubernetes_cluster_name), value = "shared" },
-    { key = "OscK8sRole/service.internal" , value = "true" }
+    { key = "OscK8sRole/service.internal", value = "true" }
   ] : []
 }
 

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "outscale_subnet" "public_subnet" {
   subregion_name = each.key
 
   dynamic "tags" {
-    for_each = concat(var.public_subnet_tags, var.tags, local.public_subnets_name[each.key], local.kubernetes_subnet_tags)
+    for_each = concat(var.public_subnet_tags, var.tags, local.public_subnets_name[each.key], local.kubernetes_public_subnet_tags)
     content {
       key   = tags.value.key
       value = tags.value.value
@@ -66,7 +66,7 @@ resource "outscale_subnet" "private_subnet" {
   subregion_name = each.key
 
   dynamic "tags" {
-    for_each = concat(var.private_subnet_tags, var.tags, local.private_subnets_name[each.key], local.kubernetes_subnet_tags)
+    for_each = concat(var.private_subnet_tags, var.tags, local.private_subnets_name[each.key], local.kubernetes_private_subnet_tags)
     content {
       key   = tags.value.key
       value = tags.value.value
@@ -175,7 +175,7 @@ resource "outscale_subnet" "storage_subnet" {
   subregion_name = each.key
 
   dynamic "tags" {
-    for_each = concat(var.storage_subnet_tags, var.tags, local.storage_subnets_name[each.key], local.kubernetes_subnet_tags)
+    for_each = concat(var.storage_subnet_tags, var.tags, local.storage_subnets_name[each.key], local.kubernetes_storage_subnet_tags)
     content {
       key   = tags.value.key
       value = tags.value.value


### PR DESCRIPTION
## Description

Change subnets tags to correspond to the latest cloud-provider-osc (Kubernetes).
This change allow you to deploy loadbalancer in public/private/storage subnets.
Cloud-provider-osc doc : https://github.com/outscale/cloud-provider-osc/tree/main/deploy

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [x] Other (specify): Update following external dependency

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

Test with a vpc that has a kubernetes deployer (cloud-provider-osc installed). Ingress-nginx is configured correctly and has its loadbalancer on the private subnets.

## Checklist

* [x] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
